### PR TITLE
add storage backed cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All the cache implementations allow you to inject policy decision callbacks.
 
 Policies help you define how the cache should behave when it is updating or hold stale data.
 
-```
+```js
 import {CacheUpdatePolicy, CachePendingPolicy} from '@criipto/cache';
 ```
 
@@ -27,6 +27,9 @@ import {CacheUpdatePolicy, CachePendingPolicy} from '@criipto/cache';
 ### Example
 
 ```js
+
+import {CacheUpdatePolicy, CachePendingPolicy, memoryCache} from '@criipto/cache';
+
 const metadataCache = memoryCache({
   updatePolicy: (url, {lastUpdatedAt}) => {
     // Update metadata if data is more than an hour old
@@ -38,6 +41,39 @@ const metadataCache = memoryCache({
   pendingPolicy: () => CachePendingPolicy.STALE,
   refresh: async (url: URL) => {
     return await fetch(url);
+  }
+});
+```
+
+## Storage backed cache
+
+### Example
+
+```js
+
+import {CacheUpdatePolicy, CachePendingPolicy, storedCache} from '@criipto/cache';
+
+const metadataCache = storedCache({
+  updatePolicy: (url, {lastUpdatedAt}) => {
+    // Update metadata if data is more than an hour old
+    if (lastUpdatedAt.valueOf() < (Date.now() - 60 * 60 * 1000)) {
+      return CacheUpdatePolicy.UPDATE;
+    }
+    return CacheUpdatePolicy.DONT_UPDATE;
+  },
+  pendingPolicy: () => CachePendingPolicy.STALE,
+  refresh: async (url: URL) => {
+    const response = await fetch(url);
+    if (response.status !== 200) throw new Error('Not 200');
+    return response.json() as Promise<{metadata: string}>
+  },
+  storage: {
+    getItem: async (url) => {
+      return await fetchFromStorageImplementation(url);
+    },
+    setItem: async (url, data) => {
+      return await upsertInStorageImplementation(url, data);
+    }
   }
 });
 ```

--- a/src/__tests__/stored-cache.test.ts
+++ b/src/__tests__/stored-cache.test.ts
@@ -1,0 +1,112 @@
+import test from "ava";
+import {
+  IStorage,
+  storedCache,
+  CachePendingPolicy,
+  CacheUpdatePolicy,
+} from "../index.js";
+import sinon from "sinon";
+import type { Json } from "../index.js";
+
+type StorageFake<TKey, TData extends Json> = IStorage<TKey, TData> & {
+  getItem: sinon.SinonSpy<
+    TKey[],
+    Promise<{ value: TData; metadata: { lastUpdatedAt: Date } } | null>
+  >;
+  setItem: sinon.SinonSpy<
+    [TKey, TData, { lastUpdatedAt: Date }],
+    Promise<void>
+  >;
+};
+
+const storageFake = <TKey, TData extends Json>(): StorageFake<TKey, TData> => {
+  return {
+    getItem: sinon.fake.resolves(null),
+    setItem: sinon.fake(),
+  };
+};
+
+test("checks storage before refreshing cache", async (t) => {
+  const expected = `my_return_val_${Math.random().toString()}`;
+  const storage = {
+    ...storageFake<string, string>(),
+    getItem: sinon.fake.resolves({
+      value: expected,
+      metadata: { lastUpdatedAt: new Date() },
+    }),
+  };
+
+  const cachedFn = storedCache<string, string>({
+    updatePolicy: () => CacheUpdatePolicy.DONT_UPDATE,
+    pendingPolicy: () => CachePendingPolicy.WAIT,
+    refresh: async () => {
+      throw new Error("nah");
+    },
+    storage,
+  });
+
+  // ACT
+  const actual = await cachedFn("key");
+
+  // ASSERT
+  t.is(storage.getItem.callCount, 1);
+  t.is(actual, expected);
+});
+
+test("refreshes if stored value does not match update policy", async (t) => {
+  const expected = `my_return_val_${Math.random().toString()}`;
+  const storage = {
+    ...storageFake<string, string>(),
+    getItem: sinon.fake.resolves({
+      value: Math.random().toString(),
+      metadata: { lastUpdatedAt: new Date("2000-01-01T00:00:00Z") },
+    }),
+  };
+
+  const cachedFn = storedCache<string, string>({
+    updatePolicy: (v, { lastUpdatedAt }) => {
+      if (Date.now() - lastUpdatedAt.valueOf() < 3600) {
+        return CacheUpdatePolicy.DONT_UPDATE;
+      }
+      return CacheUpdatePolicy.UPDATE;
+    },
+    pendingPolicy: () => CachePendingPolicy.WAIT,
+    refresh: async () => expected,
+    storage,
+  });
+
+  // ACT
+  const actual = await cachedFn("key");
+
+  // ASSERT
+  t.is(storage.getItem.callCount, 1);
+  t.is(actual, expected);
+});
+
+test("updates stored value after refresh", async (t) => {
+  const expected = `my_return_val_${Math.random().toString()}`;
+  const storage = {
+    ...storageFake<string, string>(),
+    getItem: sinon.fake.resolves(null),
+  };
+
+  const cachedFn = storedCache<string, string>({
+    updatePolicy: () => CacheUpdatePolicy.UPDATE,
+    pendingPolicy: () => CachePendingPolicy.WAIT,
+    refresh: async () => expected,
+    storage,
+  });
+
+  // ACT
+  const actual = await cachedFn("key");
+
+  // ASSERT
+  t.is(
+    storage.setItem.callCount,
+    1,
+    `setItem was not called once, but ${storage.setItem.callCount} times`
+  );
+  t.is(storage.setItem.firstCall.args[0], "key");
+  t.is(storage.setItem.firstCall.args[1], expected);
+  t.is(actual, expected);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { CacheUpdatePolicy, CachePendingPolicy } from "./policies";
 export { memoryCache } from "./memory-cache";
+export { storedCache, IStorage, Json } from "./stored-cache";

--- a/src/memory-cache.ts
+++ b/src/memory-cache.ts
@@ -19,7 +19,7 @@ function unwrap<TData>(r: UpdateResult<TData>): TData {
     .exhaustive();
 }
 
-type CacheOptions<TData, TArgs extends unknown[]> = {
+export type CacheOptions<TData, TArgs extends unknown[]> = {
   updatePolicy: (
     cachedValue: TData,
     metadata: { lastUpdatedAt: Date }

--- a/src/stored-cache.ts
+++ b/src/stored-cache.ts
@@ -1,0 +1,56 @@
+import { match } from "ts-pattern";
+import {
+  memoryCache,
+  CacheOptions as MemoryCacheOptions,
+} from "./memory-cache";
+import { CacheUpdatePolicy } from "./policies";
+
+export type JSONLiteral = String | Number | Boolean | null;
+export type JSONObject = { [key: string]: Json };
+export type Json = JSONLiteral | JSONObject | Json[];
+
+export interface IStorage<TKey, TData extends Json> {
+  getItem: (
+    key: TKey
+  ) => Promise<{ value: TData; metadata: { lastUpdatedAt: Date } } | null>;
+  setItem: (
+    key: TKey,
+    value: TData,
+    metadata: { lastUpdatedAt: Date }
+  ) => Promise<void>;
+}
+
+export type CacheOptions<TKey, TData extends Json> = MemoryCacheOptions<
+  TData,
+  TKey[]
+> & {
+  storage: IStorage<TKey, TData>;
+};
+
+/**
+ * A cache implementation that holds values in storage (as well as memory)
+ */
+export function storedCache<TKey, TData extends Json>(
+  options: CacheOptions<TKey, TData>
+): (key: TKey) => Promise<TData> {
+  const { storage, updatePolicy } = options;
+  const cache = memoryCache({
+    ...options,
+    async refresh(key: TKey) {
+      const existing = await storage.getItem(key);
+      if (existing !== null) {
+        const policy = updatePolicy(existing.value, existing.metadata);
+        return match(policy)
+          .with(CacheUpdatePolicy.DONT_UPDATE, async () => existing.value)
+          .with(CacheUpdatePolicy.UPDATE, () => options.refresh(key))
+          .exhaustive();
+      }
+      const update = await options.refresh(key);
+      await storage.setItem(key, update, { lastUpdatedAt: new Date() });
+      return update;
+    },
+  });
+  return (key: TKey): Promise<TData> => {
+    return cache(key);
+  };
+}


### PR DESCRIPTION
a superset of the memory backed cache which allows the implementer to add a storage interface that is checked before cache values are refreshed.